### PR TITLE
Automate github repo status reporting and visualization

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -28,10 +28,12 @@ jobs:
         run: |
           npm ci
           cd server && npm ci
+          echo "Installing Node 18 fetch polyfill not required (Node18 has fetch)"
 
       - name: Generate embedded data
         run: |
-          node scripts/generate-data.js || echo "⚠️ Data generation skipped (local paths not available)"
+          node scripts/github-scan.js || echo "⚠️ GitHub scan skipped"
+          node scripts/generate-data.js || echo "⚠️ Local scan skipped (local paths not available)"
           
       - name: Build React App
         run: |

--- a/README_CLOUDFLARE.md
+++ b/README_CLOUDFLARE.md
@@ -207,7 +207,18 @@ node scripts/generate-data.js
 
 **What it does**:
 1. Scans `/Users/creator/Documents/DEV`
-2. Finds all `pow3r.status.json` files
+2. Finds all `pow3r.status.json` files via:
+   - Local scan: `scripts/generate-data.js`
+   - GitHub org scan: `scripts/github-scan.js` (requires `GITHUB_TOKEN`, `GITHUB_ORG`)
+
+### Webhook + API
+
+- Endpoint: `/functions/api/webhook.js` (GitHub Webhook)
+  - Verifies `X-Hub-Signature-256` using `GITHUB_WEBHOOK_SECRET`
+  - Fetches or generates `pow3r.status.json` for the changed repo
+  - Updates `POW3R_STATUS_KV` key `projects:data`
+- Endpoint: `/functions/api/projects.js`
+  - Returns KV aggregate if present, else falls back to static `public/data.json`
 3. Finds all `dev-status.config.json` files
 4. Combines into single data.json
 5. Saves to `public/data.json`

--- a/functions/api/projects.js
+++ b/functions/api/projects.js
@@ -1,69 +1,38 @@
 /**
- * Cloudflare Pages Function - Get All Projects
- * Replaces Express /api/projects endpoint
+ * Cloudflare Pages Function - Aggregated Projects API
+ * Returns merged pow3r.status.json data from KV if available,
+ * otherwise serves bundled public/data.json.
  */
 
-// This is a static data approach since we can't scan filesystem on edge
-// In production, this should be generated during build time
+export async function onRequestGet(context) {
+  const { env } = context;
 
-export async function onRequest(context) {
-  const { request, env } = context;
-  
   try {
-    // For Cloudflare Pages, we need to embed the data
-    // This will be generated during deployment
-    
-    // Load from KV storage if configured
-    if (env.PROJECTS_KV) {
-      const data = await env.PROJECTS_KV.get('projects', { type: 'json' });
-      if (data) {
-        return new Response(JSON.stringify({
-          success: true,
-          count: data.length,
-          source: 'kv',
-          timestamp: new Date().toISOString(),
-          projects: data
-        }), {
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'public, max-age=300'
-          }
-        });
+    const kv = env.POW3R_STATUS_KV;
+    let payload = null;
+
+    if (kv) {
+      const value = await kv.get('projects:data');
+      if (value) {
+        payload = JSON.parse(value);
       }
     }
-    
-    // Fallback: Return empty array with helpful message
-    return new Response(JSON.stringify({
-      success: true,
-      count: 0,
-      source: 'static',
-      message: 'No projects configured. This static deployment needs data embedded during build.',
-      timestamp: new Date().toISOString(),
-      projects: [],
-      instructions: {
-        local: 'For local development, run: ./start-visualization.sh',
-        production: 'Configure KV storage or embed data during build'
+
+    if (!payload) {
+      // Fallback to static file
+      const url = new URL('/data.json', context.request.url);
+      const res = await fetch(url.toString());
+      if (res.ok) {
+        payload = await res.json();
+      } else {
+        payload = { success: true, count: 0, projects: [] };
       }
-    }), {
-      headers: {
-        'Content-Type': 'application/json',
-        'Cache-Control': 'public, max-age=60'
-      }
+    }
+
+    return new Response(JSON.stringify(payload), {
+      headers: { 'Content-Type': 'application/json' }
     });
-    
   } catch (error) {
-    console.error('Error in projects API:', error);
-    
-    return new Response(JSON.stringify({
-      success: false,
-      error: error.message,
-      message: 'For full functionality, run locally: ./start-visualization.sh'
-    }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json'
-      }
-    });
+    return new Response(JSON.stringify({ success: false, error: error.message }), { status: 500 });
   }
 }
-

--- a/functions/api/webhook.js
+++ b/functions/api/webhook.js
@@ -1,0 +1,134 @@
+/**
+ * Cloudflare Pages Function - GitHub Webhook
+ * Verifies signature, fetches/creates pow3r.status.json for the repo,
+ * and updates KV (projects:data) for the visualization.
+ */
+
+function timingSafeEqual(a, b) {
+  const aBuf = new TextEncoder().encode(a);
+  const bBuf = new TextEncoder().encode(b);
+  if (aBuf.length !== bBuf.length) return false;
+  let out = 0;
+  for (let i = 0; i < aBuf.length; i++) out |= aBuf[i] ^ bBuf[i];
+  return out === 0;
+}
+
+async function verifyGithubSignature(request, secret) {
+  if (!secret) return false;
+  const signature = request.headers.get('X-Hub-Signature-256');
+  if (!signature || !signature.startsWith('sha256=')) return false;
+
+  const body = await request.clone().arrayBuffer();
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const mac = await crypto.subtle.sign('HMAC', key, body);
+  const digest = Array.from(new Uint8Array(mac)).map(b => b.toString(16).padStart(2, '0')).join('');
+  const computed = `sha256=${digest}`;
+  return timingSafeEqual(signature, computed);
+}
+
+async function fetchGhJson(url, token) {
+  const res = await fetch(url, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+  if (!res.ok) throw new Error(`GitHub API error: ${res.status}`);
+  return res.json();
+}
+
+async function fetchPow3rStatus(owner, repo, ref, token) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/pow3r.status.json?ref=${encodeURIComponent(ref)}`;
+  const res = await fetch(url, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch pow3r.status.json from ${owner}/${repo}@${ref}`);
+  const meta = await res.json();
+  const decoded = atob(meta.content);
+  try {
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+}
+
+export async function onRequestPost(context) {
+  const { request, env } = context;
+  try {
+    const ok = await verifyGithubSignature(request, env.GITHUB_WEBHOOK_SECRET);
+    if (!ok) {
+      return new Response(JSON.stringify({ success: false, error: 'Invalid signature' }), { status: 401 });
+    }
+
+    const event = request.headers.get('X-GitHub-Event');
+    const payload = await request.json();
+
+    // Determine repo
+    const repo = payload.repository?.name;
+    const owner = payload.repository?.owner?.login;
+    const ref = payload.ref?.replace('refs/heads/', '') || payload.repository?.default_branch || 'main';
+    if (!repo || !owner) {
+      return new Response(JSON.stringify({ success: false, error: 'Missing repo info' }), { status: 400 });
+    }
+
+    // Try to fetch pow3r.status.json; fallback to generate minimal structure using languages/commit activity
+    let status = await fetchPow3rStatus(owner, repo, ref, env.GITHUB_TOKEN);
+
+    if (!status) {
+      const langs = await fetchGhJson(`https://api.github.com/repos/${owner}/${repo}/languages`, env.GITHUB_TOKEN).catch(() => ({}));
+      const commits = await fetchGhJson(`https://api.github.com/repos/${owner}/${repo}/stats/commit_activity`, env.GITHUB_TOKEN).catch(() => []);
+      const last4 = Array.isArray(commits) ? commits.slice(-4).reduce((s, w) => s + (w.total || 0), 0) : 0;
+      const phase = last4 > 20 ? 'green' : last4 > 0 ? 'orange' : 'gray';
+      status = {
+        graphId: `${owner}-${repo}`,
+        lastScan: new Date().toISOString(),
+        assets: [
+          {
+            id: `${repo}-root`,
+            type: 'component.ui.react',
+            source: 'github',
+            location: `https://github.com/${owner}/${repo}`,
+            metadata: { title: repo, tags: Object.keys(langs || {}) },
+            status: { phase, completeness: 0.5, qualityScore: 0.5 },
+            dependencies: { io: {}, universalConfigRef: 'v1.0' },
+            analytics: { embedding: [], connectivity: 0, centralityScore: 0.5, activityLast30Days: last4 }
+          }
+        ],
+        edges: [],
+        metadata: { owner, repo, ref, configType: 'v2' }
+      };
+    }
+
+    // Update KV aggregate
+    const kv = env.POW3R_STATUS_KV;
+    if (kv) {
+      const raw = await kv.get('projects:data');
+      let aggregate = raw ? JSON.parse(raw) : { success: true, count: 0, projects: [] };
+      const idx = aggregate.projects.findIndex(p => (p.metadata?.owner === owner && p.metadata?.repo === repo) || p.projectName === repo);
+      if (idx >= 0) {
+        aggregate.projects[idx] = status;
+      } else {
+        aggregate.projects.push(status);
+        aggregate.count = aggregate.projects.length;
+      }
+      aggregate.timestamp = new Date().toISOString();
+      await kv.put('projects:data', JSON.stringify(aggregate));
+    }
+
+    return new Response(JSON.stringify({ success: true, repo: `${owner}/${repo}`, event }), { headers: { 'Content-Type': 'application/json' } });
+  } catch (error) {
+    return new Response(JSON.stringify({ success: false, error: error.message }), { status: 500 });
+  }
+}

--- a/pow3r-graph/src/integrations/pow3rBuild.tsx
+++ b/pow3r-graph/src/integrations/pow3rBuild.tsx
@@ -70,10 +70,12 @@ export const Pow3rBuildIntegration: React.FC<Pow3rBuildIntegrationProps> = ({
 
   // Initialize with first config
   useEffect(() => {
-    if (configs.length > 0 && !selectedConfig) {
-      setSelectedConfig(configs[0]);
+    if (configs.length > 0) {
+      // Validate configs and pick the first valid one
+      const firstValid = configs.find(c => validatePow3rStatus(c).valid) || configs[0];
+      setSelectedConfig(firstValid);
     }
-  }, [configs, selectedConfig]);
+  }, [configs]);
 
   // Handle config selection
   const handleConfigSelect = useCallback((config: Pow3rStatusConfig) => {

--- a/scripts/github-scan.js
+++ b/scripts/github-scan.js
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/**
+ * GitHub Org Scanner
+ * Fetches pow3r.status.json from all repositories in an org/user
+ * and writes a consolidated public/data.json used by the 3D graph app.
+ */
+
+const fs = require('fs').promises;
+const path = require('path');
+const crypto = require('crypto');
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || process.env.PAT_GITHUB;
+const GITHUB_ORG = process.env.GITHUB_ORG || process.env.GITHUB_USER || 'memorymusicllc';
+const OUTPUT_FILE = path.join(__dirname, '../public/data.json');
+
+async function safeFetch(url, init = {}) {
+  const res = await fetch(url, init);
+  return res;
+}
+
+async function fetchJson(url, headers = {}) {
+  const res = await safeFetch(url, { headers });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`HTTP ${res.status} ${res.statusText} for ${url}: ${text}`);
+  }
+  return res.json();
+}
+
+function ghHeaders() {
+  if (!GITHUB_TOKEN) return { 'Accept': 'application/vnd.github+json' };
+  return {
+    'Accept': 'application/vnd.github+json',
+    'Authorization': `Bearer ${GITHUB_TOKEN}`,
+    'X-GitHub-Api-Version': '2022-11-28'
+  };
+}
+
+async function listAllRepos() {
+  const repos = [];
+  let page = 1;
+  while (true) {
+    const url = `https://api.github.com/orgs/${GITHUB_ORG}/repos?per_page=100&page=${page}`;
+    const data = await fetchJson(url, ghHeaders());
+    if (!Array.isArray(data) || data.length === 0) break;
+    repos.push(...data);
+    if (data.length < 100) break;
+    page += 1;
+  }
+  return repos;
+}
+
+async function getCommitActivity(owner, repo) {
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/stats/commit_activity`;
+    const data = await fetchJson(url, ghHeaders());
+    if (!Array.isArray(data)) return 0;
+    // Sum last 4 weeks
+    const last4Weeks = data.slice(-4);
+    return last4Weeks.reduce((sum, w) => sum + (w.total || 0), 0);
+  } catch {
+    return 0;
+  }
+}
+
+async function getLanguages(owner, repo) {
+  try {
+    const url = `https://api.github.com/repos/${owner}/${repo}/languages`;
+    const data = await fetchJson(url, ghHeaders());
+    return data;
+  } catch {
+    return {};
+  }
+}
+
+function inferAssetTypeFromLanguages(langs) {
+  const keys = Object.keys(langs || {}).map(k => k.toLowerCase());
+  if (keys.some(k => ['typescript', 'javascript'].includes(k))) return 'component.ui.react';
+  if (keys.some(k => ['python', 'go', 'rust', 'java', 'kotlin', 'c#', 'csharp'].includes(k))) return 'service.backend';
+  if (keys.some(k => ['markdown'].includes(k))) return 'doc.markdown';
+  return 'library.js';
+}
+
+function phaseFromCommits(commits30d) {
+  if (commits30d > 20) return 'green';
+  if (commits30d > 0) return 'orange';
+  return 'gray';
+}
+
+function sha16(input) {
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+async function getPow3rStatus(owner, repo, ref) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/pow3r.status.json?ref=${encodeURIComponent(ref)}`;
+  const res = await safeFetch(url, { headers: ghHeaders() });
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Failed to fetch pow3r.status.json from ${owner}/${repo}@${ref}`);
+  const contentMeta = await res.json();
+  if (contentMeta && contentMeta.content) {
+    const decoded = Buffer.from(contentMeta.content, 'base64').toString('utf8');
+    try {
+      const json = JSON.parse(decoded);
+      // Attach metadata for the frontend to use
+      json.metadata = {
+        ...(json.metadata || {}),
+        path: `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/pow3r.status.json`,
+        relativePath: `${repo}/pow3r.status.json`,
+        configType: 'v2',
+        owner,
+        repo,
+        ref
+      };
+      return json;
+    } catch (e) {
+      return null;
+    }
+  }
+  return null;
+}
+
+async function fetchTree(owner, repo, ref) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/git/trees/${encodeURIComponent(ref)}?recursive=1`;
+  try {
+    const data = await fetchJson(url, ghHeaders());
+    return Array.isArray(data?.tree) ? data.tree : [];
+  } catch {
+    return [];
+  }
+}
+
+function classifyDirectory(name) {
+  const n = name.toLowerCase();
+  if (['src', 'client', 'frontend', 'web', 'app'].some(p => n === p)) return { type: 'component.ui.react', category: 'Frontend' };
+  if (['server', 'backend', 'api'].some(p => n === p)) return { type: 'service.backend', category: 'Backend' };
+  if (['functions', 'workers', 'cloudflare'].some(p => n.includes(p))) return { type: 'service.serverless', category: 'Functions' };
+  if (['components', 'widgets', 'ui'].some(p => n.includes(p))) return { type: 'component.ui.react', category: 'UI Components' };
+  if (['docs', 'documentation'].some(p => n.includes(p))) return { type: 'doc.markdown', category: 'Documentation' };
+  if (['tests', '__tests__', 'e2e', 'spec'].some(p => n.includes(p))) return { type: 'test.e2e', category: 'Testing' };
+  if (['config', '.github', '.circleci'].some(p => n.includes(p))) return { type: 'config.schema', category: 'Configuration' };
+  if (['scripts', 'tools'].some(p => n.includes(p))) return { type: 'workflow.automation', category: 'Automation' };
+  return { type: 'library.js', category: 'Library' };
+}
+
+async function generateFallbackStatus(owner, repo, ref = 'main') {
+  const commits30d = await getCommitActivity(owner, repo);
+  const languages = await getLanguages(owner, repo);
+  const assetType = inferAssetTypeFromLanguages(languages);
+  const phase = phaseFromCommits(commits30d);
+  const now = new Date().toISOString();
+  const graphId = sha16(`${owner}/${repo}@${now}`);
+
+  // Build assets from tree (top-level directories)
+  const tree = await fetchTree(owner, repo, ref);
+  const topDirs = new Set();
+  for (const item of tree) {
+    if (item.type === 'tree' && item.path && !item.path.includes('/')) topDirs.add(item.path);
+  }
+
+  const assets = [];
+  // project root asset
+  assets.push({
+    id: `${repo}-root`,
+    type: assetType,
+    source: 'github',
+    location: `https://github.com/${owner}/${repo}`,
+    metadata: {
+      title: repo,
+      description: `Auto-generated status for ${owner}/${repo}`,
+      tags: Object.keys(languages),
+      version: '1.0.0',
+      authors: [],
+      createdAt: now,
+      lastUpdate: now
+    },
+    status: {
+      phase,
+      completeness: 0.6,
+      qualityScore: 0.55,
+      notes: commits30d > 0 ? 'Active repository' : 'No recent activity'
+    },
+    dependencies: {
+      io: {},
+      universalConfigRef: 'v1.0'
+    },
+    analytics: {
+      embedding: [],
+      connectivity: 0,
+      centralityScore: 0.5,
+      activityLast30Days: commits30d
+    }
+  });
+
+  const edges = [];
+  let assetIndex = 0;
+  for (const dir of topDirs) {
+    const cls = classifyDirectory(dir);
+    const assetId = `${repo}-${dir}`;
+    assets.push({
+      id: assetId,
+      type: cls.type,
+      source: 'github',
+      location: `https://github.com/${owner}/${repo}/tree/${ref}/${dir}`,
+      metadata: {
+        title: dir,
+        description: `${cls.category} directory`,
+        tags: [cls.category.toLowerCase(), ...Object.keys(languages)],
+        version: '1.0.0',
+        authors: [],
+        createdAt: now,
+        lastUpdate: now
+      },
+      status: {
+        phase,
+        completeness: 0.5,
+        qualityScore: 0.5,
+        notes: 'Generated from repository structure'
+      },
+      dependencies: { io: {}, universalConfigRef: 'v1.0' },
+      analytics: { embedding: [], connectivity: 1, centralityScore: 0.4, activityLast30Days: commits30d }
+    });
+    edges.push({ from: `${repo}-root`, to: assetId, type: 'partOf', strength: 0.9 });
+    assetIndex += 1;
+  }
+
+  return {
+    graphId,
+    lastScan: now,
+    assets,
+    edges,
+    metadata: {
+      owner,
+      repo,
+      ref,
+      path: `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/pow3r.status.json`,
+      relativePath: `${repo}/pow3r.status.json`,
+      configType: 'v2'
+    }
+  };
+}
+
+async function main() {
+  if (!GITHUB_TOKEN) {
+    console.warn('⚠️  GITHUB_TOKEN not set. Skipping GitHub scan.');
+    return 0;
+  }
+  console.log(`\n🔎 Scanning GitHub org: ${GITHUB_ORG}`);
+  const repos = await listAllRepos();
+  console.log(`📦 Found ${repos.length} repositories`);
+
+  const projects = [];
+  for (const repo of repos) {
+    const owner = repo.owner?.login || GITHUB_ORG;
+    const name = repo.name;
+    const ref = repo.default_branch || 'main';
+    try {
+      const cfg = await getPow3rStatus(owner, name, ref);
+      if (cfg) {
+        projects.push(cfg);
+        console.log(`  ✓ ${owner}/${name} → pow3r.status.json`);
+      } else {
+        const fallback = await generateFallbackStatus(owner, name);
+        projects.push(fallback);
+        console.log(`  • ${owner}/${name} → generated fallback`);
+      }
+    } catch (e) {
+      console.warn(`  ✗ ${owner}/${name}: ${e.message}`);
+    }
+  }
+
+  const data = {
+    success: true,
+    count: projects.length,
+    basePath: `github:${GITHUB_ORG}`,
+    timestamp: new Date().toISOString(),
+    generatedBy: 'github-scan.js',
+    projects
+  };
+
+  await fs.writeFile(OUTPUT_FILE, JSON.stringify(data, null, 2));
+  console.log(`\n✅ Wrote ${projects.length} projects → ${OUTPUT_FILE}`);
+  return projects.length;
+}
+
+if (require.main === module) {
+  main()
+    .then((count) => {
+      console.log(`🎉 GitHub scan complete (${count})`);
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('❌ Error:', err);
+      process.exit(1);
+    });
+}
+
+module.exports = { main };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,3 +4,8 @@ compatibility_date = "2024-01-01"
 # Pages configuration
 pages_build_output_dir = "public"
 
+[[kv_namespaces]]
+binding = "POW3R_STATUS_KV"
+id = "${POW3R_STATUS_KV_ID}"
+preview_id = "${POW3R_STATUS_KV_PREVIEW_ID}"
+


### PR DESCRIPTION
Add GitHub organization scanning and Cloudflare Pages Functions to dynamically update and serve repository status data for the 3D graph.

This PR establishes a dynamic pipeline where a GitHub scanner aggregates `pow3r.status.json` files (or generates fallbacks) into a Cloudflare KV store via a webhook. This ensures the 3D graph visualization reflects repository changes in near real-time, moving beyond static data generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-569a9381-9587-4649-9e50-1f6131ab8f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-569a9381-9587-4649-9e50-1f6131ab8f13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

